### PR TITLE
Fix non-numeric value warnings

### DIFF
--- a/fields.inc.php
+++ b/fields.inc.php
@@ -270,7 +270,7 @@ function pgbar_field_formatter_view($entity_type, $entity, $field, $instance, $l
       $theme[] = 'pgbar__' . $item['options']['display']['template'];
     }
     $theme[] = 'pgbar';
-    $current += isset($item['options']['target']['offset']) ? $item['options']['target']['offset'] : 0;
+    $current += !empty($item['options']['target']['offset']) ? $item['options']['target']['offset'] : 0;
     $target = _pgbar_select_target($item['options']['target']['target'], $current, $item['options']['target']['threshold']);
     $d = array(
       '#theme' => $theme,

--- a/src/PgbarPolling.php
+++ b/src/PgbarPolling.php
@@ -24,7 +24,7 @@ class PgbarPolling implements \Drupal\polling\FieldTypePluginInterface {
     $data['pgbar'] = [];
     foreach ($this->items as $delta => $item) {
       $item = _pgbar_add_item_defaults($item);
-      $offset = isset($item['options']['target']['offset']) ? $item['options']['target']['offset'] : 0;
+      $offset = !empty($item['options']['target']['offset']) ? $item['options']['target']['offset'] : 0;
       $data['pgbar'][$this->name][$delta] = $this->source->getValue($item) + $offset;
     }
     return $data;


### PR DESCRIPTION
Although the default value for offset is `0`, the field content often happens to be removed entirely, resulting in an empty string instead of a numeric value.